### PR TITLE
Allow resume  after stream downloading  crash 

### DIFF
--- a/pytube/monostate.py
+++ b/pytube/monostate.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
-from typing import Any
-from typing import Callable
-from typing import Optional
+from typing import Any, Awaitable, Callable, Optional
 
 
 class Monostate:
     def __init__(
         self,
-        on_progress: Optional[Callable[[Any, bytes, int], None]],
-        on_complete: Optional[Callable[[Any, Optional[str]], None]],
+        on_progress: Optional[Callable[[Any, bytes, int], Awaitable[None]]],
+        on_complete: Optional[Callable[[Any, Optional[str]], Awaitable[None]]],
         title: Optional[str] = None,
         duration: Optional[int] = None,
     ):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(os.path.join(here, "pytube", "version.py")) as fp:
 setup(
     name="pytube",
     version=__version__,  # noqa: F821
-    author="Mike Semple, Ronnie Ghose, Taylor Fox Dahlin, Nick Ficano",
+    author="Mike Semple, Ronnie Ghose, Taylor Fox Dahlin, Nick Ficano",
     author_email="hey@pytube.io",
     packages=["pytube", "pytube.contrib"],
     package_data={"": ["LICENSE"],},


### PR DESCRIPTION
aiofile decency has been removed so can you add this feature that will allow to resume downloading level when crash happens to be able to restart from where we left instead of restart from zero 